### PR TITLE
fix: use pinned version for alpine

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.13
 
 ENV DENO_VERSION=1.13.0
 


### PR DESCRIPTION
Make does not work with alpine 3.14, this commit pins the alpine version
to 3.13 to fix the issue.

Fixes #152