### PR TITLE
Check for options in the entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         run: |
           docker run -t ${{ matrix.kind }} deno run https://deno.land/std/examples/welcome.ts
           docker run -t ${{ matrix.kind }} echo 'test entry script'
+          # if typescript is present in the output, then probably deno --version worked
+          docker run -t ${{ matrix.kind }} --version | grep typescript
 
       - name: Login to Docker Hub
         if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,19 +46,23 @@ jobs:
       - name: Build image
         run: |
           docker build -f ${{ matrix.kind }}.dockerfile --build-arg BIN_IMAGE=bin -t ${{ matrix.kind }} .
+
+      - name: Test default CMD
+        run: |
           docker run -t ${{ matrix.kind }}
 
-      - name: Test basic run
+      - name: Test if entry script forwards to deno binary
         run: |
           docker run -t ${{ matrix.kind }} run https://deno.land/std/examples/welcome.ts
 
-      - name: Test entry script
+          # if typescript is present in the output, then probably deno --version worked
+          docker run -t ${{ matrix.kind }} --version | grep typescript
+
+      - name: Test if entry script forwards to other binaries
         if: ${{ matrix.kind != 'distroless' }}
         run: |
           docker run -t ${{ matrix.kind }} deno run https://deno.land/std/examples/welcome.ts
           docker run -t ${{ matrix.kind }} echo 'test entry script'
-          # if typescript is present in the output, then probably deno --version worked
-          docker run -t ${{ matrix.kind }} --version | grep typescript
 
       - name: Login to Docker Hub
         if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')

--- a/_entry.sh
+++ b/_entry.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 set -e
 
+if [ "$1" != "${1#-}" ]; then
+    # if the first argument is an option like `--help` or `-h`
+    exec deno "$@"
+fi
+
 case "$1" in
     bundle | cache | compile | completions | coverage | doc | eval | fmt | help | info | install | lint | lsp | repl | run | test | types | upgrade )
+    # if the first argument is a known deno command
     exec deno "$@";;
 esac
 


### PR DESCRIPTION
So that `docker run denoland/deno --help` also works as expected.

This follows the docker advice for official images: https://github.com/docker-library/official-images#consistency