### PR TITLE
Add `denoland/deno:bin` image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: build-bin
     name: ${{ matrix.kind }}
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         kind: ["alpine", "centos", "debian", "distroless", "ubuntu"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,66 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: ${{ matrix.kind }}
-    runs-on: ubuntu-latest-xl
-    strategy:
-      matrix:
-        kind: ['alpine', 'centos', 'debian', 'distroless', 'ubuntu']
+  build-bin:
+    runs-on: ubuntu-latest
+    outputs:
+      image-digest: ${{ steps.build-and-push.outputs.digest }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and export
+        id: build-and-push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') }}
+          tags: |
+            denoland/deno:bin-${GITHUB_REF#refs/*/}
+            denoland/deno:bin
+          outputs: type=docker,dest=/tmp/deno-bin-image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: deno-bin-image
+          path: /tmp/deno-bin-image.tar
+
+  build:
+    needs: build-bin
+    name: ${{ matrix.kind }}
+    runs-on: ubuntu-latest-xl
+    strategy:
+      matrix:
+        kind: ["alpine", "centos", "debian", "distroless", "ubuntu"]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download bin image artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: deno-bin-image
+          path: /tmp
+
+      - name: Load bin image
+        run: |
+          docker load --input /tmp/deno-bin-image.tar
+
       - name: Build image
         run: |
-          docker build -f ${{ matrix.kind }}.dockerfile -t ${{ matrix.kind }} .
+          docker build -f ${{ matrix.kind }}.dockerfile -t ${{ matrix.kind }} \
+            --build-arg BIN_IMAGE=${{ needs.build-bin.outputs.image-digest }} .
           docker run -t ${{ matrix.kind }}
 
       - name: Test basic run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build and export
-        id: build-and-export
-        uses: docker/build-push-action@v2
-        with:
-          file: bin.dockerfile
-          context: .
-          tags: bin
-          outputs: type=docker,dest=/tmp/bin-image.tar
+      - name: Build and export image
+        run: |
+          docker build -f bin.dockerfile -t bin .
+          docker save bin -o /tmp/bin-image.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 jobs:
   build-bin:
     runs-on: ubuntu-latest
-    outputs:
-      image-digest: ${{ steps.build-and-export.outputs.digest }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -20,6 +18,7 @@ jobs:
         with:
           file: bin.dockerfile
           context: .
+          tags: bin
           outputs: type=docker,dest=/tmp/bin-image.tar
 
       - name: Upload artifact
@@ -48,11 +47,12 @@ jobs:
       - name: Load bin image
         run: |
           docker load --input /tmp/bin-image.tar
+          docker inspect bin
 
       - name: Build image
         run: |
           docker build -f ${{ matrix.kind }}.dockerfile -t ${{ matrix.kind }} \
-            --build-arg BIN_IMAGE=${{ needs.build-bin.outputs.image-digest }} .
+            --build-arg BIN_IMAGE=bin .
           docker run -t ${{ matrix.kind }}
 
       - name: Test basic run
@@ -83,8 +83,8 @@ jobs:
       - name: Push bin image
         if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') && matrix.kind == 'debian'
         run: |
-          docker tag ${{ needs.build-bin.outputs.image-digest }} denoland/deno:bin-${GITHUB_REF#refs/*/}
-          docker tag ${{ needs.build-bin.outputs.image-digest }} denoland/deno:bin
+          docker tag bin denoland/deno:bin-${GITHUB_REF#refs/*/}
+          docker tag bin denoland/deno:bin
           docker push denoland/deno:bin-${GITHUB_REF#refs/*/}
           docker push denoland/deno:bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-bin:
     runs-on: ubuntu-latest
     outputs:
-      image-digest: ${{ steps.build-and-push.outputs.digest }}
+      image-digest: ${{ steps.build-and-export.outputs.digest }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -14,29 +14,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to Docker Hub
-        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Build and export
-        id: build-and-push
+        id: build-and-export
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') }}
-          tags: |
-            denoland/deno:bin-${GITHUB_REF#refs/*/}
-            denoland/deno:bin
-          outputs: type=docker,dest=/tmp/deno-bin-image.tar
+          outputs: type=docker,dest=/tmp/bin-image.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: deno-bin-image
-          path: /tmp/deno-bin-image.tar
+          name: bin-image
+          path: /tmp/bin-image.tar
 
   build:
     needs: build-bin
@@ -52,12 +41,12 @@ jobs:
       - name: Download bin image artifact
         uses: actions/download-artifact@v2
         with:
-          name: deno-bin-image
+          name: bin-image
           path: /tmp
 
       - name: Load bin image
         run: |
-          docker load --input /tmp/deno-bin-image.tar
+          docker load --input /tmp/bin-image.tar
 
       - name: Build image
         run: |
@@ -90,7 +79,15 @@ jobs:
           docker push denoland/deno:${{ matrix.kind }}-${GITHUB_REF#refs/*/}
           docker push denoland/deno:${{ matrix.kind }}
 
-      - name: Push base image (default)
+      - name: Push bin image
+        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') && matrix.kind == 'debian'
+        run: |
+          docker tag ${{ needs.build-bin.outputs.image-digest }} denoland/deno:bin-${GITHUB_REF#refs/*/}
+          docker tag ${{ needs.build-bin.outputs.image-digest }} denoland/deno:bin
+          docker push denoland/deno:bin-${GITHUB_REF#refs/*/}
+          docker push denoland/deno:bin
+
+      - name: Push default image
         if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') && matrix.kind == 'debian'
         run: |
           docker tag ${{ matrix.kind }} denoland/deno:${GITHUB_REF#refs/*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-bin:
+    name: bin
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         id: build-and-export
         uses: docker/build-push-action@v2
         with:
+          file: bin.dockerfile
           context: .
           outputs: type=docker,dest=/tmp/bin-image.tar
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -f ${{ matrix.kind }}.dockerfile -t ${{ matrix.kind }} \
-            --build-arg BIN_IMAGE=bin .
+          docker build -f ${{ matrix.kind }}.dockerfile --build-arg BIN_IMAGE=bin -t ${{ matrix.kind }} .
           docker run -t ${{ matrix.kind }}
 
       - name: Test basic run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-bin:
     name: bin
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
   build:
     needs: build-bin
     name: ${{ matrix.kind }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     strategy:
       matrix:
         kind: ["alpine", "centos", "debian", "distroless", "ubuntu"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dockerhub:
   (default)
 - Distroless: [denoland/deno:distroless](https://hub.docker.com/r/denoland/deno)
 - Ubuntu: [denoland/deno:ubuntu](https://hub.docker.com/r/denoland/deno)
+- Only the binary: [denoland/deno:bin](https://hub.docker.com/r/denoland/deno)
 
 ![ci status](https://github.com/denoland/deno_docker/workflows/ci/badge.svg?branch=main)
 
@@ -68,6 +69,18 @@ and build and run this locally:
 
 ```sh
 $ docker build -t app . && docker run -it --init -p 1993:1993 app
+```
+
+## Using your own base image
+
+If you prefer to install `deno` in your own base image, you can use the `denoland/deno:bin` to simplify the process.
+
+```Dockerfile
+FROM ubuntu
+
+ARG DENO_VERSION=1.13.2
+
+COPY --from=denoland/deno:bin-${DENO_VERSION} /deno /usr/local/bin/deno
 ```
 
 ## (optional) Add `deno` alias to your shell

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,23 +1,23 @@
+ARG DENO_VERSION=1.13.2
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
+
+
+FROM ${BIN_IMAGE} AS bin
+
+
 FROM frolvlad/alpine-glibc:alpine-3.13
 
-ENV DENO_VERSION=1.13.2
-
-RUN apk add --virtual .download --no-cache curl \
- && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
-         --output deno.zip \
- && unzip deno.zip \
- && rm deno.zip \
- && chmod 755 deno \
- && mv deno /bin/deno \
- && apk del .download
-
 RUN addgroup --gid 1000 deno \
- && adduser --uid 1000 --disabled-password deno --ingroup deno \
- && mkdir /deno-dir/ \
- && chown deno:deno /deno-dir/
+  && adduser --uid 1000 --disabled-password deno --ingroup deno \
+  && mkdir /deno-dir/ \
+  && chown deno:deno /deno-dir/
 
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
+
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /bin/deno
 
 COPY ./_entry.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh

--- a/bin.dockerfile
+++ b/bin.dockerfile
@@ -1,9 +1,11 @@
 ARG DENO_VERSION=1.13.2
 
 
-FROM alpine:3 AS download
+FROM ubuntu:20.04 AS download
 
-RUN apk add --no-cache curl unzip
+RUN apt-get update \
+  && apt-get install -y curl unzip \
+  && rm -rf /var/lib/apt/lists/*
 
 ARG DENO_VERSION
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \

--- a/bin.dockerfile
+++ b/bin.dockerfile
@@ -1,0 +1,21 @@
+ARG DENO_VERSION=1.13.2
+
+
+FROM alpine:3 AS download
+
+RUN apk add --no-cache curl unzip
+
+ARG DENO_VERSION
+RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
+    --output deno.zip \
+  && unzip deno.zip \
+  && rm deno.zip \
+  && chmod 755 deno
+
+
+FROM scratch
+
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+
+COPY --from=download /deno /deno

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,18 +1,11 @@
+ARG DENO_VERSION=1.13.2
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
+
+
+FROM ${BIN_IMAGE} AS bin
+
+
 FROM centos:8
-
-ENV DENO_VERSION=1.13.2
-
-RUN yum makecache \
- && yum install unzip -y \
- && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
-         --output deno.zip \
- && unzip deno.zip \
- && rm deno.zip \
- && chmod 755 deno \
- && mv deno /bin/deno \
- && yum remove unzip -y \
- && yum clean all \
- && rm -rf /var/cache/yum
 
 RUN groupadd -g 1993 deno \
  && adduser -u 1993 -g deno deno \
@@ -22,9 +15,12 @@ RUN groupadd -g 1993 deno \
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
 
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /bin/deno
+
 COPY ./_entry.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
-
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["run", "https://deno.land/std/examples/welcome.ts"]

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,31 +1,25 @@
+ARG DENO_VERSION=1.13.2
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
+
+
+FROM ${BIN_IMAGE} AS bin
+
+
 FROM debian:stable-slim
 
-ENV DENO_VERSION=1.13.2
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get -qq update \
- && apt-get -qq install -y --no-install-recommends curl ca-certificates unzip \
- && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
-         --output deno.zip \
- && unzip deno.zip \
- && rm deno.zip \
- && chmod 755 deno \
- && mv deno /usr/bin/deno \
- && apt-get -qq remove --purge -y curl ca-certificates unzip \
- && apt-get -y -qq autoremove \
- && apt-get -qq clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 RUN useradd --uid 1993 --user-group deno \
- && mkdir /deno-dir/ \
- && chown deno:deno /deno-dir/
+  && mkdir /deno-dir/ \
+  && chown deno:deno /deno-dir/
 
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
 
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /usr/bin/deno
+
 COPY ./_entry.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
-
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["run", "https://deno.land/std/examples/welcome.ts"]

--- a/distroless.dockerfile
+++ b/distroless.dockerfile
@@ -1,25 +1,18 @@
-FROM alpine:3.12.3
+ARG DENO_VERSION=1.13.2
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
 
-ENV DENO_VERSION=1.13.2
 
-RUN apk add --virtual .download --no-cache curl \
- && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
-         --output deno.zip \
- && unzip deno.zip \
- && rm deno.zip \
- && chmod 755 deno \
- && mv deno /bin/deno \
- && apk del .download
+FROM ${BIN_IMAGE} AS bin
 
 
 FROM gcr.io/distroless/cc
-COPY --from=0 /bin/deno /bin/deno
 
-ENV DENO_VERSION=1.13.2
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
 
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /bin/deno
 
 ENTRYPOINT ["/bin/deno"]
 CMD ["run", "https://deno.land/std/examples/welcome.ts"]
-

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -1,31 +1,25 @@
+ARG DENO_VERSION=1.13.2
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
+
+
+FROM ${BIN_IMAGE} AS bin
+
+
 FROM ubuntu:20.04
 
-ENV DENO_VERSION=1.13.2
-
-RUN apt-get -qq update \
- && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \
- && apt-get -qq install -y ca-certificates curl unzip --no-install-recommends \
- && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
-         --output deno.zip \
- && unzip deno.zip \
- && rm deno.zip \
- && chmod 755 deno \
- && mv deno /usr/bin/deno \
- && apt-get -qq remove -y ca-certificates curl unzip \
- && apt-get -y -qq autoremove \
- && apt-get -qq clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 RUN useradd --uid 1993 --user-group deno \
- && mkdir /deno-dir/ \
- && chown deno:deno /deno-dir/
+  && mkdir /deno-dir/ \
+  && chown deno:deno /deno-dir/
 
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
 
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /usr/bin/deno
+
 COPY ./_entry.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
-
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["run", "https://deno.land/std/examples/welcome.ts"]


### PR DESCRIPTION
This simplifies the build process, and also users who want to install `deno` in their own base images. This pattern is also followed by the Docker Buildx: https://hub.docker.com/r/docker/buildx-bin

For now, some additional complexities were added to the `ci.yaml` (the entire `build-ci`) stage. But I plan to also propose a simplification in another PR using the [Docker Bake Action](https://github.com/docker/bake-action) and [Docker Metadata Action](https://github.com/docker/metadata-action), thus allowing we to build everything in a single job.

Plus, some additional changes were made:

- Format `Dockerfile`s to use 2 spaces as indent delimiter
- Format `ci.yaml` with vscode-yaml
