### PR TITLE
Add example for `compile`

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.13.2
+FROM denoland/deno:distroless-1.13.2
 
 # The port that your application listens to.
 EXPOSE 1993
@@ -6,16 +6,16 @@ EXPOSE 1993
 WORKDIR /app
 
 # Prefer not to run as root.
-USER deno
+# USER deno
 
 # Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
 # Ideally cache deps.ts will download and compile _all_ external files used in main.ts.
 COPY deps.ts .
-RUN deno cache deps.ts
+RUN ["/bin/deno", "cache", "deps.ts"]
 
 # These steps will be re-run upon each file change in your working directory:
 ADD . .
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
-RUN deno cache main.ts
+RUN ["/bin/deno", "cache", "main.ts"]
 
 CMD ["run", "--allow-net", "main.ts"]

--- a/example/compile.Dockerfile
+++ b/example/compile.Dockerfile
@@ -1,0 +1,16 @@
+FROM hayd/deno:1.9.2 AS build
+
+WORKDIR /app
+
+COPY deps.ts .
+RUN deno cache deps.ts
+
+COPY . .
+RUN deno compile --allow-net --unstable --lite --output /usr/local/bin/app main.ts
+
+
+FROM gcr.io/distroless/cc:latest
+
+COPY --from=build /usr/local/bin/app /usr/local/bin/app
+
+CMD ["/usr/local/bin/app"]


### PR DESCRIPTION
Without `--lite` ([which got removed on 1.10](https://github.com/denoland/deno/issues/10507#issuecomment-857446761)) this makes no sense. But with it, it brings noticeable benefits.