### PR TITLE
Fix Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ directory as a shared volume._
 
 ## Thanks
 
-Thanks to [Andy Hayden](@hayd) for maintaining and setting up these images.
+Thanks to [Andy Hayden](https://github.com/hayd) for maintaining and setting up these images.


### PR DESCRIPTION
Currently, the link redirects to https://github.com/UltiRequiem/deno_docker/blob/main/@hayd

Which is a 404.