### PR TITLE
frolvlad/alpine-glibc:alpine: 3.13->3.17

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -13,7 +13,7 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION
   && chmod +x /tini
 
 
-FROM frolvlad/alpine-glibc:alpine-3.13
+FROM frolvlad/alpine-glibc:alpine-3.17
 
 RUN addgroup --gid 1000 deno \
   && adduser --uid 1000 --disabled-password deno --ingroup deno \


### PR DESCRIPTION
Is it possible for alpine to be bumped from 3.13 to 3.17 with any conflicts?