### PR TITLE
Alpine: Extract GLIBC from distroless.

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -12,8 +12,16 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION
     --output /tini \
   && chmod +x /tini
 
+FROM gcr.io/distroless/cc-debian12:latest-amd64 AS glibc
 
-FROM frolvlad/alpine-glibc:alpine-3.17
+FROM alpine:3.18
+
+COPY --from=glibc /lib/x86_64-linux-gnu/* /lib/x86_64-linux-gnu/
+COPY --from=glibc /etc/nsswitch.conf /etc/
+COPY --from=glibc /etc/ld.so.conf.d/x86_64-linux-gnu.conf /etc/ld.so.conf.d/
+COPY --from=glibc /usr/lib/x86_64-linux-gnu/gconv/* /usr/lib/x86_64-linux-gnu/gconv/
+
+RUN mkdir /lib64 && ln -s /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /lib64/
 
 RUN addgroup --gid 1000 deno \
   && adduser --uid 1000 --disabled-password deno --ingroup deno \


### PR DESCRIPTION
Alpine images currently rely on third-party images that have glibc installed.
By using the official alpine image and porting the missing glibc from the official distroless image, the image remains clean and has no dependencies on third-party images.