### PR TITLE
Distroless: Specify version explicitly.

### DIFF
--- a/distroless.dockerfile
+++ b/distroless.dockerfile
@@ -13,7 +13,7 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION
   && chmod +x /tini
 
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc-debian12:latest-amd64
 
 
 ENV DENO_DIR /deno-dir/


### PR DESCRIPTION
Currently, there are two types of Distroless: debian11 and 12, but for some reason the `/cc` specification points to debian11 even though the stable version of debian itself is 12.
So I decided to specify the version explicitly.