### PR TITLE
Support for multi-arch (x86 + ARM64) images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,92 +5,124 @@ on: [push, pull_request]
 jobs:
   build-bin:
     name: bin
-    runs-on: ubuntu-22.04-xl
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-
-      - name: Build and export image
-        run: |
-          docker build -f bin.dockerfile -t bin .
-          docker save bin -o /tmp/bin-image.tar
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      
+      - name: Cache docker registry
+        uses: actions/cache@v3
         with:
-          name: bin-image
-          path: /tmp/bin-image.tar
+          key: registry-${{ github.sha }}
+          path: ${{ runner.temp }}/registry
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Start local Docker registry
+        run: |
+          # Docker save / load does not support multi-arch images.
+          # This sets up a local registry that I can push the images to.
+          docker run -d -p 5000:5000 -e 'REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry' -v '${{ runner.temp }}/registry:/var/lib/registry' registry:2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Build image
+        run: |
+          docker buildx build -f bin.dockerfile --platform=linux/amd64,linux/arm64 -t localhost:5000/bin --push .
 
   build:
     needs: build-bin
     name: ${{ matrix.kind }}
-    runs-on: ubuntu-22.04-xl
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         kind: ["alpine", "centos", "debian", "distroless", "ubuntu"]
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-
-      - name: Download bin image artifact
-        uses: actions/download-artifact@v4
+      
+      - name: Cache docker registry
+        uses: actions/cache@v3
         with:
-          name: bin-image
-          path: /tmp
+          key: registry-${{ github.sha }}
+          fail-on-cache-miss: true
+          path: ${{ runner.temp }}/registry
 
-      - name: Load bin image
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Start local Docker registry
         run: |
-          docker load --input /tmp/bin-image.tar
-          docker inspect bin
+          # Docker save / load does not support multi-arch images.
+          # This sets up a local registry that I can push the images to.
+          docker run -d -p 5000:5000 -e 'REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry' -v '${{ runner.temp }}/registry:/var/lib/registry' registry:2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       - name: Build image
         run: |
-          docker build -f ${{ matrix.kind }}.dockerfile --build-arg BIN_IMAGE=bin -t ${{ matrix.kind }} .
+          docker buildx build -f ${{ matrix.kind }}.dockerfile --platform=linux/amd64,linux/arm64 --build-arg BIN_IMAGE=localhost:5000/bin -t localhost:5000/${{ matrix.kind }} --push .
 
       - name: Test default CMD
         run: |
-          docker run -t ${{ matrix.kind }}
+          docker run -t localhost:5000/${{ matrix.kind }}
 
       - name: Test if entry script forwards to deno binary
         run: |
-          docker run -t ${{ matrix.kind }} eval "console.log('Welcome to Deno!')"
+          docker run -t localhost:5000/${{ matrix.kind }} eval "console.log('Welcome to Deno!')"
 
           # if typescript is present in the output, then probably deno --version worked
-          docker run -t ${{ matrix.kind }} --version | grep typescript
+          docker run -t localhost:5000/${{ matrix.kind }} --version | grep typescript
 
       - name: Test if entry script forwards to other binaries
         if: ${{ matrix.kind != 'distroless' }}
         run: |
-          docker run -t ${{ matrix.kind }} deno eval "console.log('Welcome to Deno!')"
-          docker run -t ${{ matrix.kind }} echo 'test entry script'
+          docker run -t localhost:5000/${{ matrix.kind }} deno eval "console.log('Welcome to Deno!')"
+          docker run -t localhost:5000/${{ matrix.kind }} echo 'test entry script'
 
       - name: Login to Docker Hub
-        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')
+        if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Push named images
-        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/')
+        if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag'
         run: |
-          docker tag ${{ matrix.kind }} denoland/deno:${{ matrix.kind }}-${GITHUB_REF#refs/*/}
-          docker tag ${{ matrix.kind }} denoland/deno:${{ matrix.kind }}
-          docker push denoland/deno:${{ matrix.kind }}-${GITHUB_REF#refs/*/}
-          docker push denoland/deno:${{ matrix.kind }}
+          docker buildx imagetools create localhost:5000/${{ matrix.kind }} -t denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} -t denoland/deno:${{ matrix.kind }}
 
       - name: Push bin image
-        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') && matrix.kind == 'debian'
+        if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag' && matrix.kind == 'debian'
         run: |
-          docker tag bin denoland/deno:bin-${GITHUB_REF#refs/*/}
-          docker tag bin denoland/deno:bin
-          docker push denoland/deno:bin-${GITHUB_REF#refs/*/}
-          docker push denoland/deno:bin
+          docker buildx imagetools create localhost:5000/bin -t denoland/deno:bin-${{ github.ref_name }} -t denoland/deno:bin
 
       - name: Push default image
-        if: github.repository == 'denoland/deno_docker' && startsWith(github.ref, 'refs/tags/') && matrix.kind == 'debian'
+        if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag' && matrix.kind == 'debian'
         run: |
-          docker tag ${{ matrix.kind }} denoland/deno:${GITHUB_REF#refs/*/}
-          docker tag ${{ matrix.kind }} denoland/deno:latest
-          docker push denoland/deno:${GITHUB_REF#refs/*/}
-          docker push denoland/deno:latest
+          docker buildx imagetools create localhost:5000/${{ matrix.kind }} -t denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} -t denoland/deno:latest

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -8,7 +8,9 @@ FROM ${BIN_IMAGE} AS bin
 FROM buildpack-deps:20.04-curl AS tini
 
 ARG TINI_VERSION=0.19.0
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     --output /tini \
   && chmod +x /tini
 

--- a/bin.dockerfile
+++ b/bin.dockerfile
@@ -9,7 +9,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /var/lib/apt/lists/*
 
 ARG DENO_VERSION
-RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-$(echo $TARGETARCH | sed -e 's/arm64/aarch64/' -e 's/amd64/x86_64/')-unknown-linux-gnu.zip \
     --output deno.zip \
   && unzip deno.zip \
   && rm deno.zip \

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -8,7 +8,9 @@ FROM ${BIN_IMAGE} AS bin
 FROM buildpack-deps:20.04-curl AS tini
 
 ARG TINI_VERSION=0.19.0
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     --output /tini \
   && chmod +x /tini
 

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -8,7 +8,9 @@ FROM ${BIN_IMAGE} AS bin
 FROM buildpack-deps:20.04-curl AS tini
 
 ARG TINI_VERSION=0.19.0
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     --output /tini \
   && chmod +x /tini
 

--- a/distroless.dockerfile
+++ b/distroless.dockerfile
@@ -8,7 +8,9 @@ FROM ${BIN_IMAGE} AS bin
 FROM buildpack-deps:20.04-curl AS tini
 
 ARG TINI_VERSION=0.19.0
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     --output /tini \
   && chmod +x /tini
 

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -8,7 +8,9 @@ FROM ${BIN_IMAGE} AS bin
 FROM buildpack-deps:20.04-curl AS tini
 
 ARG TINI_VERSION=0.19.0
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+ARG TARGETARCH
+
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} \
     --output /tini \
   && chmod +x /tini
 


### PR DESCRIPTION
## Description

As mentioned in #337, Deno now provides official ARM64 builds. This PR makes the necessary changes for the `denoland/deno` images to be multi-architecture, meaning that a user on an ARM64 or x86 host can pull the same tag and be provided with an image compatible with their architecture.

cc @mmastrac @littledivy 

## Changes

- Refactors the release workflow to use a local registry for storing the multi-arch images - `docker save` and `docker load` will only work with single architecture images.
- Updates `bin.dockerfile` to handle [`TARGETARCH`](https://docs.docker.com/build/guide/multi-platform/#platform-build-arguments)
- Use the `ubuntu-latest` image. Justification: this build is essentially linking, not compiling, so it's faster if we're not waiting for a big runner to become available.