### PR TITLE
feat(ci): automate docker hub container description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           docker pull --platform linux/amd64 denoland/deno:${{ matrix.kind }}
           docker pull --platform linux/arm64 denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} 
           docker pull --platform linux/arm64 denoland/deno:${{ matrix.kind }}
+
       - name: Push bin image
         if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag' && matrix.kind == 'debian'
         run: |
@@ -148,3 +149,11 @@ jobs:
           docker pull --platform linux/amd64 denoland/deno:latest
           docker pull --platform linux/arm64 denoland/deno:${{ github.ref_name }}
           docker pull --platform linux/arm64 denoland/deno:latest
+
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: denoland/deno
+          short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
           docker pull --platform linux/arm64 denoland/deno:latest
 
       - name: Update Docker Hub Description
+        if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag' && matrix.kind == 'debian' # Only on a tag and once per run (on debian run)
         uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Docker hub container description is not being updated on docker pulls. This PR uses [dockerhub-description](https://github.com/peter-evans/dockerhub-description) GHA to keep the docker hub container description in sync with this repo's `README.md`.