### PR TITLE
push to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push named images
         if: github.repository == 'denoland/deno_docker' && github.ref_type == 'tag'
         run: |
-          docker buildx imagetools create localhost:5000/${{ matrix.kind }} -t denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} -t denoland/deno:${{ matrix.kind }}
+          docker buildx imagetools create localhost:5000/${{ matrix.kind }} -t docker.io/denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} -t docker.io/denoland/deno:${{ matrix.kind }} -t ghcr.io/denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} -t ghcr.io/denoland/deno:${{ matrix.kind }}
           docker pull --platform linux/amd64 denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} 
           docker pull --platform linux/amd64 denoland/deno:${{ matrix.kind }}
           docker pull --platform linux/arm64 denoland/deno:${{ matrix.kind }}-${{ github.ref_name }} 


### PR DESCRIPTION
Hello!

This PR adds pushing to ghcr.io in addition to docker hub.

I'm interested in using deno at my company hosted on AWS ECS and built using codebuild. I would like to use the images defined here, however because they are only available on docker hub, and our company does not use a business docker hub license, we cannot use these images. 

There are a few issues also showing interest in this use case, see: #164, #321 

There was also [a recent PR](#376) adding docker hub descriptions, it appears [GHCR expects image labels](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images) for defining source, description, and licenses. I would be happy to add those to the dockerfiles if that would be desirable.

Thanks