### PR TITLE
chore: add support of prerelease version

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -5,14 +5,18 @@ on:
   workflow_dispatch:
     inputs:
       releaseKind:
-        description: 'Kind of version bump'
+        description: 'Kind of version upgrade. If you like to only change prerelease id, select "none"'
         default: 'patch'
         type: choice
         options:
         - patch
         - minor
         - major
+        - none
         required: true
+      prereleaseId:
+        description: 'Prerelease id to append. If you don''t need append it, keep this blank'
+        type: string
 
 jobs:
   build:
@@ -39,6 +43,12 @@ jobs:
       - name: Run version bump
         run: |
           deno run --allow-read=. --allow-write=. https://deno.land/x/bmp@v0.1.0/cli.ts --${{github.event.inputs.releaseKind}}
+        if: github.event.inputs.releaseKind != 'none'
+
+      - name: Append prerelease id if necessary
+        run: |
+          deno run --allow-read=. --allow-write=. https://deno.land/x/bmp@v0.1.0/cli.ts --${{github.event.inputs.releaseKind}}
+        if: github.event.inputs.prerelease
 
       - name: Create PR
         env:

--- a/bin.dockerfile
+++ b/bin.dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 ARG DENO_VERSION
 ARG TARGETARCH
 
-RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-$(echo $TARGETARCH | sed -e 's/arm64/aarch64/' -e 's/amd64/x86_64/')-unknown-linux-gnu.zip \
+RUN curl -fsSL https://dl.deno.land/release/v${DENO_VERSION}/deno-$(echo $TARGETARCH | sed -e 's/arm64/aarch64/' -e 's/amd64/x86_64/')-unknown-linux-gnu.zip \
     --output deno.zip \
   && unzip deno.zip \
   && rm deno.zip \


### PR DESCRIPTION
This PR adds support of prerelease version upgrade with `version_bump` workflow.

Now workflow dispatch UI shows the text input for prerelease id like the below:

<img width="370" alt="Screenshot 2024-08-21 at 13 24 19" src="https://github.com/user-attachments/assets/89a2beb6-18b9-44c8-8517-59fc96cd02c5">

If you like to append prerelease id in addition to normal version upgrade, you can specify the input like the below:

Note: The below example upgrades minor version and also append prerelease id (ex. `1.45.5` -> `1.46.0-rc.1`)

<img width="361" alt="Screenshot 2024-08-21 at 13 25 55" src="https://github.com/user-attachments/assets/ec4b5e74-be1f-4f2f-b709-3b2afdc4fccf">

If you like to only change the prerelease id, you can specify the inputs like the below:

<img width="359" alt="Screenshot 2024-08-21 at 13 26 39" src="https://github.com/user-attachments/assets/3c88a6b2-d59f-4495-bd32-6c3bd8d5969c">

If you like to only perform normal upgrade, you can keep the prerelease id blank.

I tested the above scenarios in this repo https://github.com/kt3k/bmp/actions/workflows/version_bump.yml