### PR TITLE
chore: upgrade deno version in ci

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           # use a recent version instead of the latest version in case
           # the latest version ever has issues that breaks publishing
-          deno-version: v1.30.0
+          deno-version: v1.45.5
 
       - name: Run version bump
         run: |

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v1
         with:
-          # use a recent version instead of the latest version in case
-          # the latest version ever has issues that breaks publishing
           deno-version: canary
 
       - name: Run version bump

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           # use a recent version instead of the latest version in case
           # the latest version ever has issues that breaks publishing
-          deno-version: v1.45.5
+          deno-version: canary
 
       - name: Run version bump
         run: |


### PR DESCRIPTION
`version bump` CI tasks uses a very old deno version, which doesn't support `jsr:` specifier. This PR upgrades it to a recent one.