### PR TITLE
Update CMD to serve instead of run; remove deps.ts in favor of deno.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ WORKDIR /app
 # Prefer not to run as root.
 USER deno
 
-# Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
-# Ideally cache deps.ts will download and compile _all_ external files used in main.ts.
-COPY deps.ts .
-RUN deno install --entrypoint deps.ts
+# Cache the dependencies as a layer (the following two steps are re-run only when deno.json is modified).
+# Ideally cache deno.json will download and compile _all_ external files used in main.ts.
+COPY deno.json .
+RUN deno install
 
 # These steps will be re-run upon each file change in your working directory:
 COPY . .
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
 RUN deno cache main.ts
 
-CMD ["run", "--allow-net", "main.ts"]
+CMD ["serve", "--port", "1993", "main.ts"]
 ```
 
 and build and run this locally:

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -8,14 +8,14 @@ WORKDIR /app
 # Prefer not to run as root.
 USER deno
 
-# Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
-# Ideally cache deps.ts will download and compile _all_ external files used in main.ts.
-COPY deps.ts .
-RUN deno install --entrypoint deps.ts
+# Cache the dependencies as a layer (the following two steps are re-run only when deno.json is modified).
+# Ideally cache deno.json will download and compile _all_ external files used in main.ts.
+COPY deno.json .
+RUN deno install
 
 # These steps will be re-run upon each file change in your working directory:
 COPY . .
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
 RUN deno cache main.ts
 
-CMD ["run", "--allow-net", "main.ts"]
+CMD ["serve", "--port", "1993", "main.ts"]

--- a/example/deno.json
+++ b/example/deno.json
@@ -1,0 +1,3 @@
+{
+    "nodeModulesDir": "none"
+}

--- a/example/deno.json
+++ b/example/deno.json
@@ -1,3 +1,1 @@
-{
-    "nodeModulesDir": "none"
-}
+{}

--- a/example/deps.ts
+++ b/example/deps.ts
@@ -1,1 +1,0 @@
-export { serve } from "https://deno.land/std@0.77.0/http/server.ts";

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,10 +1,6 @@
-import { serve } from "./deps.ts";
+export default {
+  async fetch(request) {        
+      return new Response("Hello world!");
+  },
+};
 
-const PORT = 1993;
-const s = serve(`0.0.0.0:${PORT}`);
-const body = new TextEncoder().encode("Hello World\n");
-
-console.log(`Server started on port ${PORT}`);
-for await (const req of s) {
-  req.respond({ body });
-}


### PR DESCRIPTION
This fixes this issue:

https://github.com/denoland/deno_docker/issues/424

You can fix that issue as well by keeping the `CMD` as is, but you have to alter the `main.ts` to be:

```
Deno.serve(
    { port: 1993, hostname: "0.0.0.0" }, 
    (_req) => new Response("Hello, world")
);
```

I went with `deno serve` since you can keep all the hostname and port configs in the Dockerfile and reduce repetition.

`deps.ts` was removed in favor of `demo.json` as it, or `package.json` , [seems to be the path](https://docs.deno.com/runtime/fundamentals/configuration/
) forward in Deno 2.


