### PR TITLE
fix: musl link error with glibc libs in /usr/local/lib/ on alpine

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -19,17 +19,15 @@ FROM gcr.io/distroless/cc as cc
 FROM alpine:latest
 
 # Inspired by https://github.com/dojyorin/deno_docker_image/blob/master/src/alpine.dockerfile
-COPY --from=cc --chown=root:root --chmod=755 /lib/*-linux-gnu/* /usr/local/lib/
-COPY --from=cc --chown=root:root --chmod=755 /lib/ld-linux-* /lib/
+COPY --from=cc --chown=root:root --chmod=755 /lib /lib
 
 RUN addgroup --gid 1000 deno \
   && adduser --uid 1000 --disabled-password deno --ingroup deno \
   && mkdir /deno-dir/ \
   && chown deno:deno /deno-dir/ \
   && mkdir /lib64 \
-  && ln -s /usr/local/lib/ld-linux-* /lib64/
+  && ln -s /lib/$(arch)-linux-gnu/ld-linux-* /lib64/
 
-ENV LD_LIBRARY_PATH="/usr/local/lib"
 ENV DENO_USE_CGROUPS=1
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local


### PR DESCRIPTION
When I tried to add ffmpeg to `denoland/deno:alpine`. I got this link error.
```sh
docker run --rm -it denoland/deno:alpine sh -c 'apk add ffmpeg && ffmpeg'
```
```
Error relocating /usr/local/lib/libgcc_s.so.1: _dl_find_object: symbol not found
Error relocating /usr/local/lib/libgcc_s.so.1: __cpu_indicator_init: symbol not found
Error relocating /usr/local/lib/libgcc_s.so.1: __cpu_model: symbol not found
```
I instigated and found that is was caused by glibc libs in /usr/local/lib/, copied from gcr.io/distroless/cc.
https://github.com/denoland/deno_docker/blob/58689c6d985860ae573efd5d241e144f62acba21/alpine.dockerfile#L22

This PR fixes the issue by putting glibc libs in the same path as in gcr.io/distroless/cc.
```sh
ls /lib/$(arch)-linux-gnu/ /lib64/
```
```
/lib/x86_64-linux-gnu:
ld-linux-x86-64.so.2    libc_malloc_debug.so.0  libmemusage.so          libnss_dns.so.2         libpthread.so.0         libutil.so.1
libBrokenLocale.so.1    libdl.so.2              libmvec.so.1            libnss_files.so.2       libresolv.so.2
libanl.so.1             libgcc_s.so.1           libnsl.so.1             libnss_hesiod.so.2      librt.so.1
libc.so.6               libm.so.6               libnss_compat.so.2      libpcprofile.so         libthread_db.so.1

/lib64:
ld-linux-x86-64.so.2
```

Since `/lib/x86_64-linux-gnu` (`/lib/aarch64-linux-gnu` on arm64) is used exclusively by glibc dynamic linker, this eliminates the interference with musl and the need for environment variable `LD_LIBRARY_PATH`.