### PR TITLE
fix: restore `deno compile` output support in alpine image

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -46,6 +46,16 @@ RUN addgroup --gid 1000 deno \
   && mkdir /lib64 \
   && ln -s /usr/local/lib/glibc/ld-linux-* /lib64/
 
+# Generate a glibc ld.so.cache so glibc binaries that are NOT rpath-patched
+# (e.g. the output of `deno compile`) can find the isolated glibc libs. musl's
+# loader ignores /etc/ld.so.cache, so this stays invisible to Alpine's musl
+# packages and does not reintroduce the conflict the isolation above avoids.
+COPY --from=tini /usr/sbin/ldconfig.real /tmp/ldconfig
+RUN echo "/usr/local/lib/glibc" > /etc/ld.so.conf \
+  && /lib64/ld-linux-*.so.* --library-path /usr/local/lib/glibc \
+    /tmp/ldconfig -C /etc/ld.so.cache -f /etc/ld.so.conf \
+  && rm /tmp/ldconfig
+
 ENV DENO_USE_CGROUPS=1
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local


### PR DESCRIPTION
## Problem

Running the output of `deno compile` inside the Alpine image fails since the **2.7.8** image:

```
error while loading shared libraries: libdl.so.2: cannot open shared object file: No such file or directory
```

Fixes denoland/deno#35683.

## Root cause

This is an image regression, not a `deno` binary bug. I confirmed the compiled binaries are identical in their ELF dependencies across versions (both need `libdl.so.2`, no rpath) — the difference is purely the image:

- A binary compiled by 2.7.8 runs fine on the 2.7.7 image.
- A binary compiled by 2.7.7 fails on the 2.7.8 image.

Commit 01a6547 (#523, first shipped in the 2.7.8 image) isolated glibc libs into `/usr/local/lib/glibc/`, **dropped `ENV LD_LIBRARY_PATH`**, and rpath-patched only `/deno` and `/tini`. A `deno compile` output binary gets neither the rpath nor `LD_LIBRARY_PATH`, so its glibc loader can't find `libdl.so.2` in the isolated (non-searched) directory.

Re-adding `LD_LIBRARY_PATH` would reintroduce the exact musl-package conflict #523 fixed, because musl's loader also honors `LD_LIBRARY_PATH` and would then load the incompatible glibc `libgcc_s.so.1`.

## Fix

Generate a glibc `/etc/ld.so.cache` pointing at `/usr/local/lib/glibc`. The glibc loader consults it, so rpath-less compiled binaries resolve their libs — while **musl's loader ignores `/etc/ld.so.cache` entirely**, so the isolation from #523 is fully preserved and no conflict returns. The cache is built with the `ldconfig` already present in the existing `tini` build stage (no new base image).

## Verification (full image build, `DENO_VERSION=2.9.0`)

- ✅ `deno` runs
- ✅ **`deno compile` output runs** (the reported failure)
- ✅ `apk add nodejs` + `node` still runs — no glibc/musl conflict reintroduced